### PR TITLE
Fix docs importerror

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,30 +4,20 @@ repos:
     hooks:
     -   id: check-yaml
 
--   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.10.0  # Latest ruff version
+-   repo: https://github.com/psf/black
+    rev: 24.10.0
     hooks:
-    -   id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
-    -   id: ruff-format
+    -   id: black
+        name: black
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.13.0
     hooks:
     -   id: mypy
-        additional_dependencies: [
-                pydantic,
-                pandas-stubs,
-                types-python-dateutil,
-                types-PyYAML,
-                types-requests,
-                types-setuptools,
-                types-SQLAlchemy,
-                types-toml
-        ]
+        additional_dependencies: [types-PyYAML, types-requests, pydantic, types-setuptools]
 
 -   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.22
+    rev: 0.7.18
     hooks:
     -   id: mdformat
         additional_dependencies: [mdformat-gfm, mdformat-frontmatter, mdformat-pyproject]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,20 +4,30 @@ repos:
     hooks:
     -   id: check-yaml
 
--   repo: https://github.com/psf/black
-    rev: 24.10.0
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.10.0  # Latest ruff version
     hooks:
-    -   id: black
-        name: black
+    -   id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+    -   id: ruff-format
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.15.0
     hooks:
     -   id: mypy
-        additional_dependencies: [types-PyYAML, types-requests, pydantic, types-setuptools]
+        additional_dependencies: [
+                pydantic,
+                pandas-stubs,
+                types-python-dateutil,
+                types-PyYAML,
+                types-requests,
+                types-setuptools,
+                types-SQLAlchemy,
+                types-toml
+        ]
 
 -   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.18
+    rev: 0.7.22
     hooks:
     -   id: mdformat
         additional_dependencies: [mdformat-gfm, mdformat-frontmatter, mdformat-pyproject]

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,25 @@
+# Documentation
+
+## Overview
+
+This repository has been updated to use the `apeworx/sphinx-ape` action for generating documentation. The workflow is configured to build and publish the documentation automatically when changes are pushed to the main branch or when a release is made.
+
+## How to Use
+
+1. **Run the Documentation Workflow**: The documentation is generated automatically when you push changes to the main branch or create a release. You can also run the workflow locally using `act -j docs`.
+
+2. **Check Generated Documentation**: After the workflow runs, check the `docs/_build` directory for the generated HTML files. Open `index.html` in a web browser to view the documentation.
+
+3. **Update Documentation**: To update the documentation, modify the markdown files in the `docs` directory and push the changes to the repository.
+
+## Pre-commit Hooks
+
+The pre-commit hooks have been updated to the latest versions to ensure code quality and consistency. You can run the pre-commit hooks locally using:
+
+```bash
+pre-commit run --all-files
+```
+
+## Additional Information
+
+For more details on the changes made, refer to the PR description and the commit history. 


### PR DESCRIPTION
**What I Did**

- Updated the GitHub Actions workflow to use the apeworx/sphinx-ape@main action for building documentation.

- Updated pre-commit hooks to their latest versions.

- Added a new docs/index.md file for the documentation homepage.(Because they wanted it)


**How I Did It**

- Modified .github/workflows/docs.yaml to use the sphinx-ape action for building and publishing the docs.

- Edited .pre-commit-config.yaml to reference the latest versions of the tools.

- Created docs/index.md with the content needed for the new documentation structure.

**How to Verify**

- Run the workflow locally using act -j docs to ensure the documentation is generated correctly.

- Check the docs/_build folder and open index.html in a browser to verify everything renders as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new documentation file outlining the automated documentation generation process and instructions for local builds.
  - Updated information on running and updating pre-commit hooks.

- **Chores**
  - Updated pre-commit configuration by replacing and downgrading certain hooks and adjusting dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->